### PR TITLE
fix: change the type of argument of "validate_interface" to serialized binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/call-number/Cargo.lock
+++ b/contracts/call-number/Cargo.lock
@@ -136,7 +136,6 @@ dependencies = [
  "serde",
  "thiserror",
  "wasmer",
- "wasmer-types",
 ]
 
 [[package]]
@@ -205,6 +204,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/call-number/Cargo.toml
+++ b/contracts/call-number/Cargo.toml
@@ -30,10 +30,8 @@ cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.24" }
-wasmer-types = { version = "2.3.0", features = ["enable-serde"] }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
-wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-types = "=2.3.0"
+wasmer = { version = "2.3", default-features = false, features = ["cranelift", "universal", "singlepass"] }

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -216,7 +216,10 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/dynamic-callee-contract/Cargo.lock
+++ b/contracts/dynamic-callee-contract/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]
@@ -519,7 +520,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "wasmer",
- "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/dynamic-callee-contract/Cargo.toml
+++ b/contracts/dynamic-callee-contract/Cargo.toml
@@ -30,11 +30,9 @@ cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.24" }
-wasmer-types = { version = "2.3.0", features = ["enable-serde"] }
 serde_json = "1.0"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
-wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-types = "=2.3.0"
+wasmer = { version = "2.3", default-features = false, features = ["cranelift", "universal", "singlepass"] }

--- a/contracts/dynamic-caller-contract/Cargo.lock
+++ b/contracts/dynamic-caller-contract/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/dynamic-caller-contract/Cargo.toml
+++ b/contracts/dynamic-caller-contract/Cargo.toml
@@ -30,11 +30,10 @@ cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.24" }
-wasmer-types = { version = "2.3.0", features = ["enable-serde"] }
 serde_json = "1.0"
+wasmer-types = "2.3"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
 wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-types = "=2.3.0"

--- a/contracts/dynamic-caller-contract/src/contract.rs
+++ b/contracts/dynamic-caller-contract/src/contract.rs
@@ -195,8 +195,9 @@ pub fn try_validate_interface_err(deps: Deps, _env: Env) -> Result<Response, Con
             "not_exist",
             ([wasmer_types::Type::I32], [wasmer_types::Type::I32]).into(),
         )];
+    let binary_err_interface = serde_json::to_vec(&err_interface).unwrap();
     deps.api
-        .validate_dynamic_link_interface(&address, &err_interface)?;
+        .validate_dynamic_link_interface(&address, &binary_err_interface)?;
     Ok(Response::default())
 }
 

--- a/contracts/events/Cargo.lock
+++ b/contracts/events/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 1.0.109",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/events/Cargo.toml
+++ b/contracts/events/Cargo.toml
@@ -30,10 +30,9 @@ cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.24" }
-wasmer-types = { version = "2.2.1", features = ["enable-serde"] }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
 wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-types = "=2.3.0"
+wasmer-types = "2.3"

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/intermediate-number/Cargo.lock
+++ b/contracts/intermediate-number/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]
@@ -795,10 +796,8 @@ dependencies = [
  "cosmwasm-vm",
  "schemars",
  "serde",
- "serde_json",
  "thiserror",
  "wasmer",
- "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/intermediate-number/Cargo.toml
+++ b/contracts/intermediate-number/Cargo.toml
@@ -30,10 +30,8 @@ cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.24" }
-wasmer-types = { version = "2.3.0", features = ["enable-serde"] }
-serde_json = "1.0"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
-wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
+wasmer = { version = "2.3", default-features = false, features = ["cranelift", "universal", "singlepass"] }

--- a/contracts/number/Cargo.lock
+++ b/contracts/number/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]
@@ -942,7 +943,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "wasmer",
- "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/number/Cargo.toml
+++ b/contracts/number/Cargo.toml
@@ -35,5 +35,4 @@ serde_json = "1.0"
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
-wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-types = "=2.3.0"
+wasmer = { version = "2.3", default-features = false, features = ["cranelift", "universal", "singlepass"] }

--- a/contracts/query-queue/Cargo.lock
+++ b/contracts/query-queue/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/simple-callee/Cargo.lock
+++ b/contracts/simple-callee/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]
@@ -1375,7 +1376,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "wasmer",
- "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/simple-callee/Cargo.toml
+++ b/contracts/simple-callee/Cargo.toml
@@ -35,5 +35,4 @@ serde_json = "1.0"
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
-wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-types = "=2.3.0"
+wasmer = { version = "2.3", default-features = false, features = ["cranelift", "universal", "singlepass"] }

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/contracts/voting-with-uuid/Cargo.lock
+++ b/contracts/voting-with-uuid/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -22,6 +22,7 @@ proc-macro2 = "1.0.32"
 convert_case = "0.4.0"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde_json = "1.0"
+wasmer-types = "2.3"
 
 [dev-dependencies]
 # Needed for testing docs

--- a/packages/derive/src/callable_points.rs
+++ b/packages/derive/src/callable_points.rs
@@ -1,5 +1,4 @@
-use proc_macro2::Span;
-use proc_macro2::TokenTree;
+use proc_macro2::{Span, TokenTree};
 use quote::quote;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -160,10 +160,6 @@ pub fn callable_points(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// This macro implements functions to call dynamic linked function for attributed trait.
 ///
-/// To use this macro, the contract must declare the import
-/// `wasmer-types = { version = "2.2.1", features = ["enable-serde"] }`
-/// in Cargo.toml
-///
 /// This macro must take an attribute specifying a struct to implement the traits for.
 /// The trait must have `cosmwasm_std::Contract` as a supertrait and each
 /// methods of the trait must have `&self` receiver as its first argument.

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto;
 use std::vec::Vec;
-use wasmer_types::{ExportType, FunctionType};
 
 use crate::addresses::{Addr, CanonicalAddr};
 use crate::errors::{
@@ -404,14 +403,10 @@ impl Api for ExternalApi {
     //
     // contract is the address of the contract to validate.
     // interface is the arg for expected interface that the contract has.
-    fn validate_dynamic_link_interface(
-        &self,
-        contract: &Addr,
-        interface: &[ExportType<FunctionType>],
-    ) -> StdResult<()> {
+    fn validate_dynamic_link_interface(&self, contract: &Addr, interface: &[u8]) -> StdResult<()> {
         let contract_region = release_buffer(to_vec(contract)?);
         let contract_ptr = contract_region as u32;
-        let interface_region = release_buffer(to_vec(interface)?);
+        let interface_region = release_buffer(interface.to_vec());
         let interface_ptr = interface_region as u32;
         let result = unsafe { validate_dynamic_link_interface(contract_ptr, interface_ptr) };
         if result != 0 {

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -3,7 +3,6 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use wasmer_types::{ExportType, FunctionType};
 
 use crate::addresses::{Addr, CanonicalAddr};
 use crate::binary::Binary;
@@ -229,7 +228,7 @@ impl Api for MockApi {
     fn validate_dynamic_link_interface(
         &self,
         _contract: &Addr,
-        _interface: &[ExportType<FunctionType>],
+        _interface: &[u8],
     ) -> StdResult<()> {
         Ok(())
     }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,7 +1,6 @@
 use serde::{de::DeserializeOwned, Serialize};
 use std::marker::PhantomData;
 use std::ops::Deref;
-use wasmer_types::{ExportType, FunctionType};
 
 use crate::addresses::{Addr, CanonicalAddr};
 use crate::binary::Binary;
@@ -144,11 +143,7 @@ pub trait Api {
     /// This calls the API to validate interface
     /// Contract is the address of the contract to validate.
     /// Interface is the arg for expected interface that the contract has.
-    fn validate_dynamic_link_interface(
-        &self,
-        contract: &Addr,
-        interface: &[ExportType<FunctionType>],
-    ) -> StdResult<()>;
+    fn validate_dynamic_link_interface(&self, contract: &Addr, interface: &[u8]) -> StdResult<()>;
 
     /// Emits a debugging message that is handled depending on the environment (typically printed to console or ignored).
     /// Those messages are not persisted to chain.


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

This PR changes the type of argument of `validate_interface` from `Vec<wasmer_types::ExportType<wasmer_types::FunctionType>>` to `&[u8]`. This is for saving serializing cost in executing `validate_ineterface`.  This serialization can be done in the macro expansion.

Closes #281 

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (not needed)
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
