### PR TITLE
refactor: remove unused INSTNACE_CACHE

### DIFF
--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -2,15 +2,9 @@ use cosmwasm_std::testing::{digit_sum, riffle_shuffle};
 use cosmwasm_std::{
     Addr, BlockInfo, Coin, ContractInfo, Env, MessageInfo, Timestamp, TransactionInfo,
 };
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::sync::RwLock;
-use std::thread_local;
-use wasmer::Module;
 
 use super::querier::MockQuerier;
 use super::storage::MockStorage;
-use crate::instance::Instance;
 use crate::{Backend, BackendApi, BackendError, BackendResult, GasInfo};
 
 pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
@@ -39,13 +33,6 @@ pub fn mock_backend_with_balances(
     }
 }
 
-type MockInstance = Instance<MockApi, MockStorage, MockQuerier>;
-thread_local! {
-    // INSTANCE_CACHE and MODULE_CACHE are intended to replace wasmvm's cache layer in the mock.
-    // Unlike wasmvm, you have to initialize them yourself in the place where you test the dynamic call.
-    pub static INSTANCE_CACHE: RwLock<HashMap<String, RefCell<MockInstance>>> = RwLock::new(HashMap::new());
-    pub static MODULE_CACHE: RwLock<HashMap<String, RefCell<Module>>> = RwLock::new(HashMap::new());
-}
 /// Length of canonical addresses created with this API. Contracts should not make any assumtions
 /// what this value is.
 /// The value here must be restorable with `SHUFFLES_ENCODE` + `SHUFFLES_DECODE` in-shuffles.

--- a/packages/vm/src/testing/mod.rs
+++ b/packages/vm/src/testing/mod.rs
@@ -23,8 +23,7 @@ pub use instance::{
     test_io, MockInstanceOptions,
 };
 pub use mock::{
-    mock_backend, mock_backend_with_balances, mock_env, mock_info, MockApi, INSTANCE_CACHE,
-    MOCK_CONTRACT_ADDR,
+    mock_backend, mock_backend_with_balances, mock_env, mock_info, MockApi, MOCK_CONTRACT_ADDR,
 };
 pub use querier::MockQuerier;
 pub use result::{TestingError, TestingResult};


### PR DESCRIPTION
# Description
`INSTANCE_CACHE` is a thread-local variable used in some tests for old dynamic link way.
https://github.com/Finschia/cosmwasm/blob/9161e25b9fa7f99bffde55af9601d2c0610347f1/packages/vm/src/testing/mock.rs#L43-L48

But, it is not used after #273. So This should be removed.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Closes #295 

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/Finschia/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have added tests to cover my changes. (not needed)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
