### PR TITLE
feat: add get_caller_addr to deps.api

### DIFF
--- a/contracts/dynamic-callee-contract/tests/integration.rs
+++ b/contracts/dynamic-callee-contract/tests/integration.rs
@@ -35,6 +35,15 @@ fn required_exports() -> Vec<(String, FunctionType)> {
             String::from("_get_callable_points_properties"),
             ([], [Type::I32]).into(),
         ),
+        (
+            String::from("caller_address"),
+            ([Type::I32], [Type::I32]).into(),
+        ),
+        (String::from("reentrancy"), ([Type::I32], []).into()),
+        (
+            String::from("call_caller_address_of"),
+            ([Type::I32, Type::I32], [Type::I32]).into(),
+        ),
     ]
 }
 

--- a/contracts/dynamic-caller-contract/schema/execute_msg.json
+++ b/contracts/dynamic-caller-contract/schema/execute_msg.json
@@ -69,9 +69,33 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "call_caller_address_of"
+      ],
+      "properties": {
+        "call_caller_address_of": {
+          "type": "object",
+          "required": [
+            "target"
+          ],
+          "properties": {
+            "target": {
+              "$ref": "#/definitions/Addr"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"

--- a/contracts/dynamic-caller-contract/src/contract.rs
+++ b/contracts/dynamic-caller-contract/src/contract.rs
@@ -233,8 +233,10 @@ pub fn try_call_caller_address_of(
     };
     let result_addr = contract.call_caller_address_of(target);
 
-    let res =
-        Response::default().add_attribute("call_caller_address_is_as_expected", (result_addr == address).to_string());
+    let res = Response::default().add_attribute(
+        "call_caller_address_is_as_expected",
+        (result_addr == address).to_string(),
+    );
 
     Ok(res)
 }

--- a/contracts/dynamic-caller-contract/src/contract.rs
+++ b/contracts/dynamic-caller-contract/src/contract.rs
@@ -234,7 +234,7 @@ pub fn try_call_caller_address_of(
     let result_addr = contract.call_caller_address_of(target);
 
     let res =
-        Response::default().add_attribute("is_as_expected", (result_addr == address).to_string());
+        Response::default().add_attribute("call_caller_address_is_as_expected", (result_addr == address).to_string());
 
     Ok(res)
 }

--- a/contracts/dynamic-caller-contract/src/msg.rs
+++ b/contracts/dynamic-caller-contract/src/msg.rs
@@ -15,6 +15,7 @@ pub enum ExecuteMsg {
     DoPanic {},
     ValidateInterface {},
     ValidateInterfaceErr {},
+    CallCallerAddressOf { target: Addr },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/dynamic-caller-contract/tests/integration.rs
+++ b/contracts/dynamic-caller-contract/tests/integration.rs
@@ -43,6 +43,21 @@ fn required_imports() -> Vec<(String, String, FunctionType)> {
             module_name.to_string(),
             ([Type::I32], []).into(),
         ),
+        (
+            String::from("reentrancy"),
+            module_name.to_string(),
+            ([Type::I32], []).into(),
+        ),
+        (
+            String::from("caller_address"),
+            module_name.to_string(),
+            ([Type::I32], [Type::I32]).into(),
+        ),
+        (
+            String::from("call_caller_address_of"),
+            module_name.to_string(),
+            ([Type::I32, Type::I32], [Type::I32]).into(),
+        ),
     ]
 }
 

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -248,6 +248,10 @@ impl Api for MockApi {
     fn add_attributes(&self, _attributes: &[Attribute]) -> StdResult<()> {
         Ok(())
     }
+
+    fn get_caller_addr(&self) -> StdResult<Addr> {
+        Err(StdError::generic_err("This cannot be used in mock"))
+    }
 }
 
 /// Returns a default enviroment with height, time, chain_id, and contract address

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -160,6 +160,9 @@ pub trait Api {
 
     /// This issues attributes to the event manager in the context data
     fn add_attributes(&self, attributes: &[Attribute]) -> StdResult<()>;
+
+    /// Returns the caller address if it is a callee of dynamic link
+    fn get_caller_addr(&self) -> StdResult<Addr>;
 }
 
 /// A short-hand alias for the two-level query result (1. accessing the contract, 2. executing query in the contract)

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -27,6 +27,7 @@ const SUPPORTED_IMPORTS: &[&str] = &[
     "env.add_events",
     "env.add_attribute",
     "env.add_attributes",
+    "env.get_caller_addr",
     "env.debug",
     "env.query_chain",
     #[cfg(feature = "iterator")]

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -13,8 +13,8 @@ use crate::errors::{CommunicationError, VmError, VmResult};
 use crate::imports::{
     do_abort, do_add_attribute, do_add_attributes, do_add_event, do_add_events,
     do_addr_canonicalize, do_addr_humanize, do_addr_validate, do_db_read, do_db_remove,
-    do_db_write, do_debug, do_ed25519_batch_verify, do_ed25519_verify, do_query_chain,
-    do_secp256k1_recover_pubkey, do_secp256k1_verify, do_sha1_calculate,
+    do_db_write, do_debug, do_ed25519_batch_verify, do_ed25519_verify, do_get_caller_addr,
+    do_query_chain, do_secp256k1_recover_pubkey, do_secp256k1_verify, do_sha1_calculate,
 };
 #[cfg(feature = "iterator")]
 use crate::imports::{do_db_next, do_db_scan};
@@ -265,6 +265,12 @@ where
         env_imports.insert(
             "add_attributes",
             Function::new_native_with_env(store, env.clone(), do_add_attributes),
+        );
+
+        // Returns caller address if it is a callee of the dynamic link
+        env_imports.insert(
+            "get_caller_addr",
+            Function::new_native_with_env(store, env.clone(), do_get_caller_addr),
         );
 
         import_obj.register("env", env_imports);


### PR DESCRIPTION
# Description
This PR adds a way to get the caller address from dynamic link callee contracts.

And, this PR updates some sample contracts to test getting the caller address from the callee. The callee can call the same code's contract as a new callee. (only `get_caller_addr`)

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/Finschia/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (leave it to the issue to making dynamic link document)
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
