### PR TITLE
fix: delete outdated serde json

### DIFF
--- a/contracts/call-number/Cargo.toml
+++ b/contracts/call-number/Cargo.toml
@@ -29,7 +29,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.24" }
+thiserror = "1.0.24"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/dynamic-callee-contract/Cargo.lock
+++ b/contracts/dynamic-callee-contract/Cargo.lock
@@ -517,7 +517,6 @@ dependencies = [
  "cosmwasm-vm",
  "schemars",
  "serde",
- "serde_json",
  "thiserror",
  "wasmer",
 ]

--- a/contracts/dynamic-callee-contract/Cargo.toml
+++ b/contracts/dynamic-callee-contract/Cargo.toml
@@ -29,8 +29,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.24" }
-serde_json = "1.0"
+thiserror = "1.0.24"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/dynamic-caller-contract/Cargo.lock
+++ b/contracts/dynamic-caller-contract/Cargo.lock
@@ -517,7 +517,6 @@ dependencies = [
  "cosmwasm-vm",
  "schemars",
  "serde",
- "serde_json",
  "thiserror",
  "wasmer",
  "wasmer-types",

--- a/contracts/dynamic-caller-contract/Cargo.toml
+++ b/contracts/dynamic-caller-contract/Cargo.toml
@@ -29,8 +29,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.24" }
-serde_json = "1.0"
+thiserror = "1.0.24"
 wasmer-types = "2.3"
 
 [dev-dependencies]

--- a/contracts/dynamic-caller-contract/src/contract.rs
+++ b/contracts/dynamic-caller-contract/src/contract.rs
@@ -210,7 +210,7 @@ pub fn try_validate_interface_err(deps: Deps, _env: Env) -> Result<Response, Con
             "not_exist",
             ([wasmer_types::Type::I32], [wasmer_types::Type::I32]).into(),
         )];
-    let binary_err_interface = serde_json::to_vec(&err_interface).unwrap();
+    let binary_err_interface = to_vec(&err_interface).unwrap();
     deps.api
         .validate_dynamic_link_interface(&address, &binary_err_interface)?;
     Ok(Response::default())

--- a/contracts/events/Cargo.toml
+++ b/contracts/events/Cargo.toml
@@ -29,7 +29,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.24" }
+thiserror = "1.0.24"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/intermediate-number/Cargo.toml
+++ b/contracts/intermediate-number/Cargo.toml
@@ -29,7 +29,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.24" }
+thiserror = "1.0.24"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/number/Cargo.lock
+++ b/contracts/number/Cargo.lock
@@ -940,7 +940,6 @@ dependencies = [
  "cosmwasm-vm",
  "schemars",
  "serde",
- "serde_json",
  "thiserror",
  "wasmer",
 ]

--- a/contracts/number/Cargo.toml
+++ b/contracts/number/Cargo.toml
@@ -29,8 +29,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.24" }
-serde_json = "1.0"
+thiserror = "1.0.24"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/simple-callee/Cargo.lock
+++ b/contracts/simple-callee/Cargo.lock
@@ -1373,7 +1373,6 @@ dependencies = [
  "cosmwasm-vm",
  "schemars",
  "serde",
- "serde_json",
  "thiserror",
  "wasmer",
 ]

--- a/contracts/simple-callee/Cargo.toml
+++ b/contracts/simple-callee/Cargo.toml
@@ -29,8 +29,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.24" }
-serde_json = "1.0"
+thiserror = "1.0.24"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/voting-with-uuid/Cargo.toml
+++ b/contracts/voting-with-uuid/Cargo.toml
@@ -37,7 +37,7 @@ cosmwasm-storage = { path = "../../packages/storage"}
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 hex = "0.4"
-thiserror = { version = "1.0.23" }
+thiserror = "1.0.23"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -96,12 +96,7 @@ pub fn entry_point(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This macro generates callable points for functions with `#[callable_point]`
 /// which can be called with dynamic link.
 ///
-/// To use this macro, the contract must declare the import
-/// `serde_json = "1.0"`
-/// in Cargo.toml
-///
 /// `#[callable_point]` is used as a mark, not as an attribute macro.
-///
 /// Functions with `#[callable_point]` are exposed to the outside world,
 /// those without `#[callable_point]` are not.
 ///


### PR DESCRIPTION
# Description
https://github.com/Finschia/cosmwasm/blob/eda535b09ef7501752d633eb32eebc46cb1c9b92/packages/derive/src/lib.rs#L99-L101 is outdated and this is not needed in contracts using `#[callable_points]`
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

This PR
- deletes this comment
- removes not needed serde_json dependency from contracts
- formats a little in some Cargo.toml files

Closes #311

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/Finschia/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have added tests to cover my changes. (not needed)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
